### PR TITLE
Add IMGPROXY_TTL env to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ $ xxd -g 2 -l 64 -p /dev/random | tr -d '\n'
 * `IMGPROXY_DOWNLOAD_TIMEOUT` — the maximum duration (in seconds) for downloading the source image. Default: `5`;
 * `IMGPROXY_CONCURRENCY` — the maximum number of image requests to be processed simultaneously. Default: double number of CPU cores;
 * `IMGPROXY_MAX_CLIENTS` — the maximum number of simultaneous active connections. Default: `IMGPROXY_CONCURRENCY * 5`;
+* `IMGPROXY_TTL` — duration in seconds sent in `Expires` and `Cache-Control: max-age` headers. Default: `3600` (1 hour);
 
 #### Security
 


### PR DESCRIPTION
1. Users should be made aware the endpoint allows caching
2. Depending on context users may want to increase the TTL to a very large number (for example when serving as an Origin for CloudFront Distribution or other CDN).