### PR TITLE
Add /health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ You can find helpful code snippets in the `examples` folder.
 
 imgproxy supports only the most popular image formats of the moment: PNG, JPEG, GIF and WebP.
 
+## Deployment
+
+There is a special endpoint `/health`, which returns HTTP Status `200 OK` after server successfully starts. This can be used to check container readiness.   
+
 ## Author
 
 Sergey "DarthSim" Aleksandrovich

--- a/server.go
+++ b/server.go
@@ -175,6 +175,12 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		panic(invalidSecretErr)
 	}
 
+	if r.URL.Path == "/health" {
+		rw.WriteHeader(200);
+		rw.Write([]byte("imgproxy is running"));
+		return
+	}
+
 	imgURL, procOpt, err := parsePath(r)
 	if err != nil {
 		panic(newError(404, err.Error(), "Invalid image url"))


### PR DESCRIPTION
Returns 200 OK after server starts.

This greatly simplifies container deployment. For example,
Kubernetes can be configured to not route traffic to imgproxy Pods
that did not pass Readiness check against /health. (https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#define-a-liveness-http-request)

Another option is returning generic about/help page for `/`. I figured an explicit `/health` endpoint is less intrusive and more readable in Readiness checks.