### PR TITLE
correct Cache-contol header missusage.

### DIFF
--- a/server.go
+++ b/server.go
@@ -107,7 +107,7 @@ func respondWithImage(r *http.Request, rw http.ResponseWriter, data []byte, imgU
 	gzipped := strings.Contains(r.Header.Get("Accept-Encoding"), "gzip") && conf.GZipCompression > 0
 
 	rw.Header().Set("Expires", time.Now().Add(time.Second*time.Duration(conf.TTL)).Format(http.TimeFormat))
-	rw.Header().Set("Cache-Control", fmt.Sprintf("Cache-Control: max-age=%d", conf.TTL))
+	rw.Header().Set("Cache-Control", fmt.Sprintf("max-age=%d, public", conf.TTL))
 	rw.Header().Set("Content-Type", mimes[po.format])
 	if gzipped {
 		rw.Header().Set("Content-Encoding", "gzip")


### PR DESCRIPTION
Cache-control header value is currently wrongly set.
For a TTL set to 3600s, the raw header value is set to "Cache-Control: Cache-Control: max-age=3600".
The correction set the value to "Cache-Control: max-age=3600, public" to nicely fit most CDNs requirements.