### PR TITLE
Add option for reading images from local filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ $ xxd -g 2 -l 64 -p /dev/random | tr -d '\n'
 * `IMGPROXY_CONCURRENCY` — the maximum number of image requests to be processed simultaneously. Default: double number of CPU cores;
 * `IMGPROXY_MAX_CLIENTS` — the maximum number of simultaneous active connections. Default: `IMGPROXY_CONCURRENCY * 5`;
 * `IMGPROXY_TTL` — duration in seconds sent in `Expires` and `Cache-Control: max-age` headers. Default: `3600` (1 hour);
+* `IMGPROXY_LOCAL_FILESYSTEM_ROOT` — root directory path for serving images from local filesystem via `local:///image.ext`. Default: disabled
 
 #### Security
 

--- a/config.go
+++ b/config.go
@@ -85,6 +85,8 @@ type config struct {
 	Salt []byte
 
 	Secret string
+
+	LocalFileSystemRoot string
 }
 
 var conf = config{
@@ -98,6 +100,7 @@ var conf = config{
 	MaxSrcResolution: 16800000,
 	Quality:          80,
 	GZipCompression:  5,
+	LocalFileSystemRoot: "",
 }
 
 func init() {
@@ -131,6 +134,8 @@ func init() {
 	hexFileConfig(&conf.Salt, *saltpath)
 
 	strEnvConfig(&conf.Secret, "IMGPROXY_SECRET")
+
+	strEnvConfig(&conf.LocalFileSystemRoot, "IMGPROXY_LOCAL_FILESYSTEM_ROOT")
 
 	if len(conf.Key) == 0 {
 		log.Fatalln("Key is not defined")
@@ -185,6 +190,20 @@ func init() {
 		log.Fatalf("GZip compression should be greater than or quual to 0, now - %d\n", conf.GZipCompression)
 	} else if conf.GZipCompression > 9 {
 		log.Fatalf("GZip compression can't be greater than 9, now - %d\n", conf.GZipCompression)
+	}
+
+	if conf.LocalFileSystemRoot != "" {
+		stat, err := os.Stat(conf.LocalFileSystemRoot)
+		if err != nil {
+			log.Fatalf("Cannot use local directory: %s", err)
+		} else {
+			if !stat.IsDir() {
+				log.Fatalf("Cannot use local directory: not a directory")
+			}
+		}
+		if conf.LocalFileSystemRoot == "/" {
+			log.Print("Exposing root via IMGPROXY_LOCAL_FILESYSTEM_ROOT is unsafe")
+		}
 	}
 
 	initVips()

--- a/download.go
+++ b/download.go
@@ -56,8 +56,13 @@ func (r *netReader) GrowBuf(s int) {
 }
 
 func initDownloading() {
+	transport := &http.Transport{}
+	if conf.LocalFileSystemRoot != "" {
+		transport.RegisterProtocol("local", http.NewFileTransport(http.Dir(conf.LocalFileSystemRoot)))
+	}
 	downloadClient = &http.Client{
 		Timeout: time.Duration(conf.DownloadTimeout) * time.Second,
+		Transport: transport,
 	}
 }
 


### PR DESCRIPTION
By default go's net/http does not support `file://` urls for security reasons. But for some use cases it may be proficient to be able to read source images from local filesystem.

This PR adds `IMGPROXY_LOCAL_FILESYSTEM_ROOT` config variable for `local://` urls, disabled by default.