### PR TITLE
Fix cmyk profile path

### DIFF
--- a/vips.h
+++ b/vips.h
@@ -160,7 +160,7 @@ vips_need_icc_import(VipsImage *in) {
 
 int
 vips_icc_import_go(VipsImage *in, VipsImage **out, char *profile) {
-  return vips_icc_import(in, out, "input_profile", "cmyk.icm", "embedded", TRUE, "pcs", VIPS_PCS_XYZ, NULL);
+  return vips_icc_import(in, out, "input_profile", profile, "embedded", TRUE, "pcs", VIPS_PCS_XYZ, NULL);
 }
 
 int


### PR DESCRIPTION
This fixes a typo in cmyk profile loading that causes
```
| 500 | VipsIcc: File 'cmyk.icm' not found
icc_import: unable to open profile "cmyk.icm"
icc_import: no input profile
```
