### PR TITLE
Update Elixir example

### DIFF
--- a/examples/signature.ex
+++ b/examples/signature.ex
@@ -1,7 +1,7 @@
 defmodule App.Imgproxy do
   @prefix "https://imgproxy.mybiz.xyz"
-  @key Base.decode16!("943b421c9eb07c830af81030552c86009268de4e532ba2ee2eab8247c6da0881")
-  @salt Base.decode16!("520f986b998545b4785e0defbc4f3c1203f22de2374a3d53cb7a7fe9fea309c5")
+  @key Base.decode16!("943b421c9eb07c830af81030552c86009268de4e532ba2ee2eab8247c6da0881", case: :lower)
+  @salt Base.decode16!("520f986b998545b4785e0defbc4f3c1203f22de2374a3d53cb7a7fe9fea309c5", case: :lower)
 
   def build_url(img_url, opts) do
     path = build_path(img_url, opts)


### PR DESCRIPTION
`Base.decode16!/2` only accepts uppercase strings as default so the elixir example does not work out of the box.