### PR TITLE
Option to use plain source urls

### DIFF
--- a/config.go
+++ b/config.go
@@ -143,6 +143,8 @@ type config struct {
 
 	BaseURL string
 
+	PlainSourceURL bool
+
 	Presets presets
 }
 
@@ -161,6 +163,7 @@ var conf = config{
 	GZipCompression:       5,
 	ETagEnabled:           false,
 	S3Enabled:             false,
+	PlainSourceURL:        false,
 }
 
 func init() {
@@ -218,6 +221,7 @@ func init() {
 	boolEnvConfig(&conf.ETagEnabled, "IMGPROXY_USE_ETAG")
 
 	strEnvConfig(&conf.BaseURL, "IMGPROXY_BASE_URL")
+	boolEnvConfig(&conf.PlainSourceURL, "IMGPROXY_PLAIN_SOURCE_URL")
 
 	conf.Presets = make(presets)
 	presetEnvConfig(conf.Presets, "IMGPROXY_PRESETS")

--- a/docs/generating_the_url_basic.md
+++ b/docs/generating_the_url_basic.md
@@ -50,6 +50,21 @@ When set to `0`, imgproxy will not enlarge the image if it is smaller than the g
 
 The source URL should be encoded with URL-safe Base64. The encoded URL can be split with `/` for your needs.
 
+#### Plain URL
+
+When `IMGPROXY_PLAIN_SOURCE_URL` is enabled URL is expected to be without encoding.
+However URL extension must be set to target format and original file extension
+must be placed in front of URL:
+
+```
+# original -> prepared
+path/to/file.png -> png/path/to/file.png # without conversion
+path/to/file.png -> png/path/to/file.jpg # convert to jpg
+# malformed URLs
+path/to/file -> /path/to/file.jpg
+path/to/file. -> ./path/to/file.jpg # dot must be kept
+```
+
 #### Extension
 
 Extension specifies the format of the resulting image. At the moment, imgproxy supports only `jpg`, `png` and `webp`, them being the most popular and useful image formats on the Web.

--- a/processing_options.go
+++ b/processing_options.go
@@ -174,7 +174,7 @@ func (po *processingOptions) presetUsed(name string) {
 	po.UsedPresets = append(po.UsedPresets, name)
 }
 
-func decodeURL(parts []string) (string, string, error) {
+func decodeBase64URL(parts []string) (string, string, error) {
 	var extension string
 
 	urlParts := strings.Split(strings.Join(parts, ""), ".")
@@ -193,6 +193,34 @@ func decodeURL(parts []string) (string, string, error) {
 	}
 
 	return string(url), extension, nil
+}
+
+func decodePlainURL(parts []string) (string, string, error) {
+	if len(parts) < 2 {
+		return "", "", errInvalidURLEncoding
+	}
+	sourceExtension, pathParts := parts[0], parts[1:len(parts)-1]
+	filanameParts := strings.Split(parts[len(parts)-1], ".")
+	if len(filanameParts) < 2 {
+		return "", "", errInvalidURLEncoding
+	}
+	basenameParts := filanameParts[:len(filanameParts)-1]
+	extension := filanameParts[len(filanameParts)-1]
+	filename := strings.Join(basenameParts, ".")
+	if sourceExtension == "." {
+		filename += "."
+	} else if len(sourceExtension) > 0 {
+		filename += "." + sourceExtension
+	}
+	return strings.Join(append(pathParts, filename), "/"), extension, nil
+}
+
+func decodeURL(parts []string) (string, string, error) {
+	if conf.PlainSourceURL {
+		return decodePlainURL(parts)
+	} else {
+		return decodeBase64URL(parts)
+	}
 }
 
 func applyWidthOption(po *processingOptions, args []string) error {

--- a/processing_options_test.go
+++ b/processing_options_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodePlainUrl(t *testing.T) {
+	decodeStr := func(s string) []string {
+		path, ext, err := decodePlainURL(strings.Split(s, "/"))
+		assert.Nil(t, err)
+		return []string{path, ext}
+	}
+	assert.Equal(t, []string{"path/to/file.jpg", "jpg"}, decodeStr("jpg/path/to/file.jpg"))
+	assert.Equal(t, []string{"path/to/file.png", "jpg"}, decodeStr("png/path/to/file.jpg"))
+	assert.Equal(t, []string{"path/to/file.jpg", "png"}, decodeStr("jpg/path/to/file.png"))
+	assert.Equal(t, []string{"path/to/file", "jpg"}, decodeStr("/path/to/file.jpg"))
+	assert.Equal(t, []string{"path/to/file.", "jpg"}, decodeStr("./path/to/file.jpg"))
+}


### PR DESCRIPTION
Hi! This is second pr to make urls more user-friendly.

It introduces `PlainSourceURL ` option which disables base 64 decoding of source url. To avoid double extensions in urls (`.jpg.jpg` or `.png.jpg`) I've decided to move source extension in front of urls.

Here are examples of urls (with truncated signature from #88):
```
with new option disabled: 
/QsqUhBDJtdU/fit/64/64/ce/1/L2Fzc2V0cy9pbWFnZXMvMS8yLzMucG5n.jpg 

enabled:
/EPjBZdh5zf4/fit/64/64/ce/1/png/assets/images/1/2/3.jpg 
```