### PR TITLE
move healthcheck before the secret checking

### DIFF
--- a/server.go
+++ b/server.go
@@ -219,14 +219,14 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		panic(errInvalidMethod)
 	}
 
-	if !checkSecret(r) {
-		panic(errInvalidSecret)
-	}
-
 	if r.URL.RequestURI() == healthPath {
 		rw.WriteHeader(200)
 		rw.Write(imgproxyIsRunningMsg)
 		return
+	}
+
+	if !checkSecret(r) {
+		panic(errInvalidSecret)
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Since health checks on AWS target groups do not support sending headers, it's impossible to use the health check when a secret is configured.

I think the health won't cost more resources than the panic, if not less, so I think it's safe to move this before the secret check.