### PR TITLE
adds truncated signature example for PHP

### DIFF
--- a/examples/signature-truncated.php
+++ b/examples/signature-truncated.php
@@ -1,5 +1,7 @@
 <?php
 
+define('IMGPROXY_SIGNATURE_SIZE', 8 );
+
 $key = '943b421c9eb07c830af81030552c86009268de4e532ba2ee2eab8247c6da0881';
 $salt = '520f986b998545b4785e0defbc4f3c1203f22de2374a3d53cb7a7fe9fea309c5';
 
@@ -24,7 +26,8 @@ $url = 'http://img.example.com/pretty/image.jpg';
 $encodedUrl = rtrim(strtr(base64_encode($url), '+/', '-_'), '=');
 
 $path = "/{$resize}/{$width}/{$height}/{$gravity}/{$enlarge}/{$encodedUrl}.{$extension}";
-
-$signature = rtrim(strtr(base64_encode(hash_hmac('sha256', $saltBin.$path, $keyBin, true)), '+/', '-_'), '=');
+$signature = hash_hmac('sha256', $saltBin.$path, $keyBin, true);
+$signature = pack('A'.IMGPROXY_SIGNATURE_SIZE, $signature);
+$signature = rtrim(strtr(base64_encode($signature), '+/', '-_'), '=');
 
 print(sprintf("/%s%s", $signature, $path));

--- a/examples/signature.php
+++ b/examples/signature.php
@@ -1,5 +1,7 @@
 <?php
 
+define('IMGPROXY_SIGNATURE_SIZE', 8 );
+
 $key = '943b421c9eb07c830af81030552c86009268de4e532ba2ee2eab8247c6da0881';
 $salt = '520f986b998545b4785e0defbc4f3c1203f22de2374a3d53cb7a7fe9fea309c5';
 
@@ -24,7 +26,8 @@ $url = 'http://img.example.com/pretty/image.jpg';
 $encodedUrl = rtrim(strtr(base64_encode($url), '+/', '-_'), '=');
 
 $path = "/{$resize}/{$width}/{$height}/{$gravity}/{$enlarge}/{$encodedUrl}.{$extension}";
-
-$signature = rtrim(strtr(base64_encode(hash_hmac('sha256', $saltBin.$path, $keyBin, true)), '+/', '-_'), '=');
+$signature = hash_hmac('sha256', $saltBin.$path, $keyBin, true);
+$signature = pack('A'.IMGPROXY_SIGNATURE_SIZE, $signature);
+$signature = rtrim(strtr(base64_encode($signature), '+/', '-_'), '=');
 
 print(sprintf("/%s%s", $signature, $path));


### PR DESCRIPTION
following #115 i've added an example on how to use signature size for php