### PR TITLE
Update installation.md

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -39,7 +39,6 @@ $ git push heroku master
 
   ```bash
   # macOS
-  $ brew tap homebrew/science
   $ brew install vips
 
   # Ubuntu


### PR DESCRIPTION
`vips` was migrated to `homebrew/core`, so it's not necessary to use `science` tap anymore